### PR TITLE
Make `Dhat` constructor private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ use thousands::Separable;
 /// file. Only one value of this type should be created; if subsequent values
 /// of this type are created they will have no effect.
 #[derive(Debug)]
-pub struct Dhat;
+pub struct Dhat(());
 
 impl Dhat {
     /// Initiate allocation profiling. This should be the first thing in
@@ -223,7 +223,7 @@ impl Dhat {
         } else {
             eprintln!("dhat: error: A second `Dhat` object was initialized");
         }
-        Dhat
+        Dhat(())
     }
 }
 


### PR DESCRIPTION
This avoids typos where a `Dhat` struct is constructed but doesn't actually do anything.

I have a doctest for this locally, but I don't think it adds much to the documentation. Let me know if I should add it.

```
diff --git a/src/lib.rs b/src/lib.rs
index 59408d0..c01413f 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,8 +193,12 @@ use thousands::Separable;
 /// When the first value of this type is dropped, profiling data is written to
 /// file. Only one value of this type should be created; if subsequent values
 /// of this type are created they will have no effect.
+///
+/// ```compile_fail,E0603
+/// let dhat = dhat::Dhat;
+/// ```
```