### PR TITLE
Use a more popular version of fxhash crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools::profiling"]
 
 [dependencies]
 backtrace = "0.3.50"
-fxhash = "0.2"
+rustc-hash = "1.1"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,8 @@
 //! - Common frames at the bottom of backtraces, below `main`, are omitted.
 
 use backtrace::SymbolName;
-use fxhash::FxHashMap;
 use lazy_static::lazy_static;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;


### PR DESCRIPTION
rustc-hash is the "standard" version of FxHash crate, which is used by
the compiler, salsa incremental computation library, rust-analyzer,
etc.