### PR TITLE
Pin to a higher version of `backtrace`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools::profiling"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-backtrace = "0.3.50"
+backtrace = "0.3.55"
 rustc-hash = "1.1"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
I tried compiling this crate and encountered the following compilation error:

```
error[E0599]: no method named `colno` found for reference `&BacktraceSymbol` in the current scope
   --> /home/pierre/.cargo/registry/src/github.com-1ecc6299db9ec823/dhat-0.2.1/src/lib.rs:483:40
    |
483 | ...                   symbol.colno().unwrap_or(0),
    |                              ^^^^^ method not found in `&BacktraceSymbol`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `dhat`
```

It turns out that `backtrace` version 0.3.50 indeed didn't include any `colno()` method. More recent versions do. Running `cargo update -p backtrace` fixed the error.
Since it took me a few minutes to investigate the problem, this PR saves this from other people.