### PR TITLE
Use std::sync::Mutex instead of parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ categories = ["development-tools::profiling"]
 backtrace = "0.3.63"
 rustc-hash = "1.1"
 lazy_static = "1.4"
-parking_lot = "0.11.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thousands = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,7 +363,7 @@
 
 use backtrace::SymbolName;
 use lazy_static::lazy_static;
-use parking_lot::Mutex;
+use std::sync::Mutex;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use std::alloc::{GlobalAlloc, Layout, System};
@@ -1112,7 +1112,7 @@ impl ProfilerBuilder {
         let ignore_allocs = IgnoreAllocs::new();
         std::assert!(!ignore_allocs.was_already_ignoring_allocs);
 
-        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
         match phase {
             Phase::Ready => {
                 let file_name = if let Some(file_name) = self.file_name {
@@ -1215,7 +1215,7 @@ unsafe impl GlobalAlloc for Alloc {
         if ignore_allocs.was_already_ignoring_allocs {
             System.alloc(layout)
         } else {
-            let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+            let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
             let ptr = System.alloc(layout);
             if ptr.is_null() {
                 return ptr;
@@ -1239,7 +1239,7 @@ unsafe impl GlobalAlloc for Alloc {
         if ignore_allocs.was_already_ignoring_allocs {
             System.realloc(old_ptr, layout, new_size)
         } else {
-            let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+            let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
             let new_ptr = System.realloc(old_ptr, layout, new_size);
             if new_ptr.is_null() {
                 return new_ptr;
@@ -1281,7 +1281,7 @@ unsafe impl GlobalAlloc for Alloc {
         if ignore_allocs.was_already_ignoring_allocs {
             System.dealloc(ptr, layout)
         } else {
-            let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+            let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
             System.dealloc(ptr, layout);
 
             if let Phase::Running(g @ Globals { heap: Some(_), .. }) = phase {
@@ -1317,7 +1317,7 @@ pub fn ad_hoc_event(weight: usize) {
     let ignore_allocs = IgnoreAllocs::new();
     std::assert!(!ignore_allocs.was_already_ignoring_allocs);
 
-    let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+    let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
     if let Phase::Running(g @ Globals { heap: None, .. }) = phase {
         let bt = new_backtrace!(g);
         let pp_info_idx = g.get_pp_info(bt, PpInfo::new_ad_hoc);
@@ -1332,7 +1332,7 @@ impl Profiler {
         let ignore_allocs = IgnoreAllocs::new();
         std::assert!(!ignore_allocs.was_already_ignoring_allocs);
 
-        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
         match std::mem::replace(phase, Phase::Ready) {
             Phase::Ready => unreachable!(),
             Phase::Running(g) => {
@@ -1635,7 +1635,7 @@ impl HeapStats {
         let ignore_allocs = IgnoreAllocs::new();
         std::assert!(!ignore_allocs.was_already_ignoring_allocs);
 
-        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
         match phase {
             Phase::Ready => {
                 panic!("dhat: getting heap stats when no profiler is running")
@@ -1659,7 +1659,7 @@ impl AdHocStats {
         let ignore_allocs = IgnoreAllocs::new();
         std::assert!(!ignore_allocs.was_already_ignoring_allocs);
 
-        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+        let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
         match phase {
             Phase::Ready => {
                 panic!("dhat: getting ad hoc stats when no profiler is running")
@@ -1685,7 +1685,7 @@ where
     let ignore_allocs = IgnoreAllocs::new();
     std::assert!(!ignore_allocs.was_already_ignoring_allocs);
 
-    let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock();
+    let phase: &mut Phase<Globals> = &mut TRI_GLOBALS.lock().unwrap();
     match phase {
         Phase::Ready => panic!("dhat: asserting when no profiler is running"),
         Phase::Running(g) => {


### PR DESCRIPTION
`parking_lot` will use the global allocator internally. This can result in
deadlock in some circumstances.

It appears that `std::sync::Mutex` is implemented (on UNIX systems) via
libc's `pthread_mutex_t`. Since libc isn't aware of Rust's global
allocator, it can't call into the dhat allocator.

Here's a sample backtrace that I was observing during deadlock. It looks like it's incomplete (I think GDB skipped inline stack frames), but it's hopefully still helpful :)

```
#0  0x00007fb02a0b9189 in syscall () from /lib64/libc.so.6
#1  0x000055a605a33681 in parking_lot_core::thread_parker::imp::ThreadParker::futex_wait (self=0x7fb029fcf330, ts=...) at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/thread_parker/linux.rs:112
#2  <parking_lot_core::thread_parker::imp::ThreadParker as parking_lot_core::thread_parker::ThreadParkerT>::park (self=<optimized out>) at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/thread_parker/linux.rs:66
#3  parking_lot_core::word_lock::WordLock::lock_slow::{{closure}} (thread_data=0x7fb029fcf318) at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/word_lock.rs:167
#4  parking_lot_core::word_lock::with_thread_data (f=...) at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/word_lock.rs:67
#5  parking_lot_core::word_lock::WordLock::lock_slow (self=<optimized out>) at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/word_lock.rs:136
#6  0x000055a605bc904b in parking_lot_core::word_lock::WordLock::lock (self=0x55a606fabc00) at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/word_lock.rs:97
#7  parking_lot_core::parking_lot::grow_hashtable (num_threads=8) at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/parking_lot.rs:252
#8  parking_lot_core::parking_lot::ThreadData::new () at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/parking_lot.rs:156
#9  0x000055a605bc8588 in parking_lot_core::parking_lot::with_thread_data::THREAD_DATA::__init () at /home/ec2-user/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.8.5/src/parking_lot.rs:178
#10 core::ops::function::FnOnce::call_once () at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/core/src/ops/function.rs:227
#11 std::thread::local::lazy::LazyKeyInner<T>::initialize (self=<optimized out>, init=<optimized out>) at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/std/src/thread/local.rs:445
#12 std::thread::local::fast::Key<T>::try_initialize (self=<optimized out>, init=<optimized out>) at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/std/src/thread/local.rs:623
#13 0x000055a605a2f7dc in std::thread::local::fast::Key<T>::get (self=<optimized out>, init=<optimized out>) at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/std/src/thread/local.rs:606
#14 parking_lot_core::parking_lot::with_thread_data::THREAD_DATA::__getit () at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/std/src/thread/local.rs:325
#15 std::thread::local::LocalKey<T>::try_with (self=<optimized out>, f=...) at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/std/src/thread/local.rs:412
#34 std::thread::Builder::spawn_unchecked_::{{closure}} () at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/std/src/thread/mod.rs:497
#35 core::ops::function::FnOnce::call_once{{vtable-shim}} () at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/core/src/ops/function.rs:227
#36 0x000055a605c6a9d3 in <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once () at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/alloc/src/boxed.rs:1854
#37 <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once () at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996/library/alloc/src/boxed.rs:1854
#38 std::sys::unix::thread::Thread::new::thread_start () at /rustc/0c292c9667f1b202a9150d58bdd2e89e3e803996//library/std/src/sys/unix/thread.rs:108
#39 0x00007fb02a58744b in start_thread () from /lib64/libpthread.so.0
#40 0x00007fb02a0be40f in clone () from /lib64/libc.so.6
```

[`parking_lot_core::parking_lot::grow_hashtable`](https://github.com/Amanieu/parking_lot/blob/1cf12744d097233316afa6c8b7d37389e4211756/core/src/parking_lot.rs#L294) calls [`HashTable::new`](https://github.com/Amanieu/parking_lot/blob/1cf12744d097233316afa6c8b7d37389e4211756/core/src/parking_lot.rs#L75), which calls `Vec::with_capacity`, which will invoke the dhat allocator.