### PR TITLE
use minimal mutex (mintex) instead of parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools::profiling"]
 
 [dependencies]
 backtrace = "0.3.63"
+mintex = "0.1.2"
 rustc-hash = "1.1"
 lazy_static = "1.4"
 parking_lot = "0.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,7 +363,7 @@
 
 use backtrace::SymbolName;
 use lazy_static::lazy_static;
-use parking_lot::Mutex;
+use mintex::Mutex;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use std::alloc::{GlobalAlloc, Layout, System};


### PR DESCRIPTION
I like dhat and would like to add feature support for it to a project I work on. However, I can't use it with parking-lot, it panics after just a few seconds of execution. Perhaps you would consider this PR? I'm happy to use a different mutex implementation if you like, or perhaps add this as a feature option, but it would be nice if I could have some change so that I could use dhat.

minimal mutex (mintex) doesn't allocate and is just a very simple spinlock. I've used it with a dhat enabled project for a few weeks and had no problems. With parking-lot, I can't even get my project to run for more than a few seconds.

To measure its impact I did some performance testing against alternatives and mintex performed well:

I modified maktlad lock-bench to add support for mintex and ran it on my Apple M1:
(https://github.com/matklad/lock-bench)

I used 8 threads, since my laptop has 8 cores. I ran the tests on my linux machine with 16 cores and the results were broadly in line with these. I don't have access to a Windows development machine for testing on that platform, but hope it would be similar.

Options {
    n_threads: 8,
    n_locks: 2,
    n_ops: 10000,
    n_rounds: 100,
}

std::sync::Mutex     avg 5.955845ms   min 2.327083ms   max 8.388ms
parking_lot::Mutex   avg 3.668027ms   min 2.025416ms   max 6.828875ms
spin::Mutex          avg 3.965942ms   min 1.793458ms   max 13.357666ms
AmdSpinlock          avg 3.837075ms   min 1.4935ms     max 5.063708ms
mintex::Mutex        avg 4.094493ms   min 1.07ms       max 15.163541ms

std::sync::Mutex     avg 5.8234ms     min 3.231875ms   max 8.411583ms
parking_lot::Mutex   avg 3.647528ms   min 1.751333ms   max 5.787625ms
spin::Mutex          avg 3.873165ms   min 1.215458ms   max 6.470375ms
AmdSpinlock          avg 4.043303ms   min 1.593291ms   max 15.180875ms
mintex::Mutex        avg 3.807157ms   min 1.745291ms   max 12.313208ms

Options {
    n_threads: 8,
    n_locks: 64,
    n_ops: 10000,
    n_rounds: 100,
}

std::sync::Mutex     avg 3.87692ms    min 1.907708ms   max 5.4575ms
parking_lot::Mutex   avg 2.316633ms   min 796.875µs    max 3.229625ms
spin::Mutex          avg 2.053121ms   min 664.166µs    max 3.013666ms
AmdSpinlock          avg 2.041948ms   min 768.208µs    max 3.32425ms
mintex::Mutex        avg 2.025226ms   min 862.666µs    max 4.3495ms

std::sync::Mutex     avg 3.880233ms   min 2.389208ms   max 5.927666ms
parking_lot::Mutex   avg 2.27687ms    min 994.375µs    max 4.314833ms
spin::Mutex          avg 2.060172ms   min 914.541µs    max 2.865666ms
AmdSpinlock          avg 1.988237ms   min 798.708µs    max 3.304041ms
mintex::Mutex        avg 2.024725ms   min 774.25µs     max 3.019041ms

Options {
    n_threads: 8,
    n_locks: 1000,
    n_ops: 10000,
    n_rounds: 100,
}

std::sync::Mutex     avg 3.52483ms    min 2.103958ms   max 5.907416ms
parking_lot::Mutex   avg 2.223817ms   min 1.160416ms   max 3.179083ms
spin::Mutex          avg 1.948454ms   min 798.416µs    max 3.342833ms
AmdSpinlock          avg 1.922102ms   min 822.333µs    max 3.125ms
mintex::Mutex        avg 1.953113ms   min 925.791µs    max 8.529916ms

std::sync::Mutex     avg 3.613345ms   min 2.075791ms   max 5.949375ms
parking_lot::Mutex   avg 2.124018ms   min 1.056083ms   max 2.797625ms
spin::Mutex          avg 1.954257ms   min 957.291µs    max 3.578833ms
AmdSpinlock          avg 1.963485ms   min 807.708µs    max 3.727666ms
mintex::Mutex        avg 1.854151ms   min 879.416µs    max 3.011375ms

Options {
    n_threads: 8,
    n_locks: 1000000,
    n_ops: 10000,
    n_rounds: 100,
}

std::sync::Mutex     avg 1.60779ms    min 1.0525ms     max 9.682041ms
parking_lot::Mutex   avg 3.375496ms   min 335.5µs      max 6.478208ms
spin::Mutex          avg 2.981603ms   min 249.708µs    max 6.05675ms
AmdSpinlock          avg 3.159886ms   min 1.602458ms   max 6.561208ms
mintex::Mutex        avg 2.966406ms   min 444.625µs    max 6.978625ms

std::sync::Mutex     avg 1.579513ms   min 1.00975ms    max 5.658083ms
parking_lot::Mutex   avg 3.544607ms   min 343.291µs    max 7.957208ms
spin::Mutex          avg 2.94142ms    min 1.375708ms   max 6.056458ms
AmdSpinlock          avg 3.065568ms   min 640.333µs    max 6.733166ms
mintex::Mutex        avg 2.943732ms   min 1.355ms      max 5.67125ms