### PR TITLE
Add `Profiler::finish_into_string(self) -> String`.

### DIFF
--- a/tests/ad-hoc.rs
+++ b/tests/ad-hoc.rs
@@ -19,13 +19,11 @@ fn main() {
     dhat::ad_hoc_event(3);
 
     let mem = {
-        let mut profiler = std::mem::ManuallyDrop::new(
-            dhat::Profiler::builder()
-                .ad_hoc()
-                .trim_backtraces(Some(usize::MAX))
-                .eprint_json()
-                .build(),
-        );
+        let profiler = dhat::Profiler::builder()
+            .ad_hoc()
+            .trim_backtraces(Some(usize::MAX))
+            .eprint_json()
+            .build();
 
         let stats = dhat::AdHocStats::get();
         assert_eq!(stats.total_events, 0);
@@ -41,7 +39,7 @@ fn main() {
         assert_eq!(stats.total_events, 4);
         assert_eq!(stats.total_units, 106);
 
-        profiler.drop_and_get_memory_output()
+        profiler.finish_into_string()
     };
 
     // Ignored because profiling has finished.
@@ -149,8 +147,8 @@ fn main() {
         assert!(y("ad_hoc::f2 (dhat-rs/tests/ad-hoc.rs:6:5)"));
         assert!(y("ad_hoc::f1 (dhat-rs/tests/ad-hoc.rs:10:5)"));
         assert!(y("ad_hoc::f1 (dhat-rs/tests/ad-hoc.rs:11:5)"));
-        assert!(y("ad_hoc::main (dhat-rs/tests/ad-hoc.rs:34:9)"));
-        assert!(y("ad_hoc::main (dhat-rs/tests/ad-hoc.rs:35:9)"));
+        assert!(y("ad_hoc::main (dhat-rs/tests/ad-hoc.rs:32:9)"));
+        assert!(y("ad_hoc::main (dhat-rs/tests/ad-hoc.rs:33:9)"));
     }
 
     // This stuff should be removed by backtrace trimming.

--- a/tests/heap.rs
+++ b/tests/heap.rs
@@ -12,12 +12,10 @@ fn main() {
     let mut v4 = vec![1u32, 2, 3, 4];
 
     let mem = {
-        let mut profiler = std::mem::ManuallyDrop::new(
-            dhat::Profiler::builder()
-                .trim_backtraces(Some(usize::MAX))
-                .eprint_json()
-                .build(),
-        );
+        let profiler = dhat::Profiler::builder()
+            .trim_backtraces(Some(usize::MAX))
+            .eprint_json()
+            .build();
 
         // Things allocated beforehand aren't counted.
         let stats = dhat::HeapStats::get();
@@ -60,7 +58,7 @@ fn main() {
         assert_eq!(stats.max_bytes, 1432);
 
         drop(v6);
-        profiler.drop_and_get_memory_output()
+        profiler.finish_into_string()
     };
 
     // Allocated before, freed after.
@@ -173,10 +171,10 @@ fn main() {
         }
     } else {
         assert!(y("alloc::vec::Vec<T,A>::push"));
-        assert!(y("heap::main (dhat-rs/tests/heap.rs:35:9)")); // v3
-        assert!(y("heap::main (dhat-rs/tests/heap.rs:38:18)")); // v5
-        assert!(y("heap::main (dhat-rs/tests/heap.rs:39:22)")); // v6
-        assert!(y("heap::main (dhat-rs/tests/heap.rs:49:22)")); // _v7
+        assert!(y("heap::main (dhat-rs/tests/heap.rs:33:9)")); // v3
+        assert!(y("heap::main (dhat-rs/tests/heap.rs:36:18)")); // v5
+        assert!(y("heap::main (dhat-rs/tests/heap.rs:37:22)")); // v6
+        assert!(y("heap::main (dhat-rs/tests/heap.rs:47:22)")); // _v7
     }
 
     // This stuff should be removed by backtrace trimming.


### PR DESCRIPTION
Thanks for making this. I successfully integrated it into my server such that I can produce heap profiles on demand. However, I noticed the following quality of life issues:
- I had to use a `#[doc(hidden)]` function
  - And I had to call `std::mem::forget` too to avoid a double-drop (your tests used `ManuallyDrop`)
- It produces unwanted stderr output

This PR addresses these issues, at the cost of making the API a bit more confusing (you can set an output path and then have it be ignored when you finish into a `String`).