### PR TITLE
Utilize const `Mutex::new` to initialize `TRI_GLOBALS`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ categories = ["development-tools::profiling"]
 
 [dependencies]
 backtrace = "0.3.63"
-mintex = "0.1.2"
+# mintex = "0.1.2"
+# todo: waiting for https://github.com/garypen/mintex/pull/3
+mintex = { git = "https://github.com/Myriad-Dreamin/mintex", rev = "674408377b25ced0018b2a443a4da92baa234658" }
 rustc-hash = "1.1"
-lazy_static = "1.4"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,7 @@ categories = ["development-tools::profiling"]
 
 [dependencies]
 backtrace = "0.3.63"
-# mintex = "0.1.2"
-# todo: waiting for https://github.com/garypen/mintex/pull/3
-mintex = { git = "https://github.com/Myriad-Dreamin/mintex", rev = "674408377b25ced0018b2a443a4da92baa234658" }
+mintex = "0.1.4"
 rustc-hash = "1.1"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,6 @@
 //! test runner code interfering with the tests.
 
 use backtrace::SymbolName;
-use lazy_static::lazy_static;
 // In normal Rust code, the allocator is on a lower level than the mutex
 // implementation, which means the mutex implementation can use the allocator.
 // But DHAT implements an allocator which requires a mutex. If we're not
@@ -391,9 +390,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use thousands::Separable;
 
-lazy_static! {
-    static ref TRI_GLOBALS: Mutex<Phase<Globals>> = Mutex::new(Phase::Ready);
-}
+static TRI_GLOBALS: Mutex<Phase<Globals>> = Mutex::new(Phase::Ready);
 
 // State transition diagram:
 //


### PR DESCRIPTION
Since the uses of `lazy_static` and `once_cell` are moving the implementations in the rust standard library, the `std::sync::{OnceLock, LazyLock}`, `dhat-rs` becomes the last user of `lazy_static` from my `Cargo.lock`. I think of the use in dhat-rs, and find that we could use neither `lazy_static` nor `std::sync::LazyLock` but constant initialize it. Candidate changes:
- either use `once_cell` because there are still crates using `once_cell`.
- ~~or wait for https://github.com/garypen/mintex/pull/3, and constant initialize `TRI_GLOBALS`.~~
  - It is in mintex v0.1.4