### PR TITLE
Use rustc-hash `2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["development-tools::profiling"]
 [dependencies]
 backtrace = "0.3.63"
 mintex = "0.1.2"
-rustc-hash = "1.1"
+rustc-hash = "2"
 lazy_static = "1.4"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Please check it. rustc-hash has released 2.0.0 for months, and you could verify the performance statement in the changelog:

> Replace hash with faster and better finalized hash. This replaces the previous "fxhash" algorithm originating in Firefox with a custom hasher designed and implemented by Orson Peters ([@orlp](https://github.com/orlp)). It was measured to have slightly better performance for rustc, has better theoretical properties and also includes a significantly better string hasher.
